### PR TITLE
Raise watchOS deployment target to v9 to clear SwiftPM deprecation warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -117,7 +117,7 @@ let package = Package(
     platforms: [
         .iOS(.v13),
         .macOS(.v10_13),
-        .watchOS(.v4),
+        .watchOS(.v9),
         .tvOS(.v12),
         .visionOS(.v1)
     ],

--- a/Tests/SPM/Package.swift
+++ b/Tests/SPM/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [
         .iOS(.v11),
         .macOS(.v10_13),
-        .watchOS(.v4),
+        .watchOS(.v9),
         .tvOS(.v11)
     ],
     dependencies: [


### PR DESCRIPTION
## What

Bump the declared minimum watchOS deployment target from `.v4` to `.v9` in `Package.swift` and the `Tests/SPM` test manifest.

## Why

Recent Swift toolchains (e.g. Xcode 27 / Swift 6.4) emit a deprecation warning when resolving the package:

> `'v4' is deprecated: watchOS 9.0 is the oldest supported version`

watchOS releases earlier than 9.0 can no longer be targeted by current SDKs, so `.watchOS(.v4)` is both deprecated and effectively inert. Bumping to the supported floor (`.v9`) clears the warning with no functional change for any currently-buildable platform.

## Scope

- `Package.swift` — main package manifest (the source of the warning that consumers see in Xcode).
- `Tests/SPM/Package.swift` — same line, for consistency.

Left `.iOS(.v11)` / `.tvOS(.v11)` in the test manifest untouched to keep this change scoped to the watchOS deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)