### PR TITLE
Define NDEBUG for release builds of the SQLCipher C target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,11 @@ import PackageDescription
 /// Compile-time options
 /// - seealso: [Recommended Compile-time Options](https://sqlite.org/compile.html#recommended_compile_time_options)
 let compileTimeOptions: [CSetting] = [
+    // SwiftPM does not define NDEBUG for C targets even in release
+    // builds, so sqlite3.c ships with its internal assert()s (and their
+    // documented ~3x overhead) enabled. Compile them out for release,
+    // matching what the autoconf/CMake builds do.
+    .define("NDEBUG", .when(configuration: .release)),
     // https://sqlite.org/compile.html#dqs
     .define("SQLITE_DQS", to: "0", .when(traits: ["DQS_0"])),
     .define("SQLITE_DQS", to: "1", .when(traits: ["DQS_1"])),


### PR DESCRIPTION
SwiftPM does not define `NDEBUG` for C targets even in `-c release` builds, so `sqlite3.c` compiles with its internal `assert()`s enabled — SQLite documents ~3x overhead with assertions on ([sqlite.org/compile.html](https://www.sqlite.org/compile.html#recommended_compile_time_options)). The autoconf/CMake builds of SQLCipher define `NDEBUG` in production; this one-liner brings the SwiftPM build in line, gated on `.when(configuration: .release)` so debug builds keep the asserts.

Verified: `swift build --target SQLCipher` (debug) and `swift build -c release --target SQLCipher` both green on macOS 15 / Swift 6.1.

(Found while adopting swift-sqlcipher as the store engine for a macOS daemon — thanks for maintaining this packaging, it replaced our hand-vendored amalgamation outright.)